### PR TITLE
Make max Method Length 30 lines

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -14,6 +14,9 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/MethodLength:
+  Max: 30
+
 Layout/LineLength:
   Max: 100
 


### PR DESCRIPTION
Increase default "MethodLength" maximum to 30. This is overwritten in all the Rubocop todo files currently with higher numbers but it's what we want to strive for and want Hound to mention. The default is 10 which is unrealistically low.