### PR TITLE
Enable StyleCollectionMethods

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -44,6 +44,9 @@ Bundler/OrderedGems:
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 
+Style/CollectionMethods:
+  Enabled: true
+
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   


### PR DESCRIPTION
Force the use of CollectionMethods: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CollectionMethods

```
# These examples are based on the default mapping for `PreferredMethods`.

# bad
items.collect
items.collect!
items.inject
items.detect
items.find_all
items.member?

# good
items.map
items.map!
items.reduce
items.find
items.select
items.include?
```