### PR TITLE
Update MultilineCallIndentation, FirstHashElementIndentation and DescribedClass

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -116,3 +116,12 @@ Layout/EmptyLinesAroundMethodBody:
   
 Lint/SuppressedException:
   AllowComments: true
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+RSpec/DescribedClass:
+  EnforcedStyle: explicit


### PR DESCRIPTION
Add rules that are currently set on the `.rubocop.yml` on `backend` and apply them generally to the styleguide since they should be applied to all our projects.