### PR TITLE
Enabled EmptyLinesAroundMethodBody to prevent new lines at the start or end of methods

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,4 +1,4 @@
-require: 
+require:
   - rubocop-performance
   - rubocop-rails
 
@@ -22,7 +22,7 @@ Metrics/ModuleLength:
 
 Metrics/MethodLength:
   Max: 30
-  
+
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
@@ -31,7 +31,7 @@ Layout/LineLength:
 
 Rails:
   Enabled: true
-  
+
 Rails/ActiveRecordAliases:
   Enabled: false
 
@@ -49,7 +49,7 @@ Style/CollectionMethods:
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
-  
+
 Style/HashTransformKeys:
   Enabled: true
 
@@ -80,10 +80,10 @@ Style/Alias:
 Style/RegexpLiteral:
   EnforcedStyle: slashes
   AllowInnerSlashes: true
-  
+
 Style/NegatedIf:
   Enabled: false
-  
+
 Style/GuardClause:
   Enabled: false
 
@@ -112,8 +112,8 @@ Layout/IndentationWidth:
   Width: 2
 
 Layout/EmptyLinesAroundMethodBody:
-  Enabled: false
-  
+  Enabled: true
+
 Lint/SuppressedException:
   AllowComments: true
 


### PR DESCRIPTION
### What?

Enforce `Layout/EmptyLinesAroundMethodBody` from our generic Ruby style guide.

### Why?

Now that the team is growing and we're introducing remote teams, we need to improve our style guides to be even stricter. I noticed a lot of trailing newlines at the end of methods in Feng Cheng's [PR](https://github.com/streemau/backend/pull/12905/files) and didn't realise we didn't already enforce this one.