### PR TITLE
Use plugins for rubocop-performance and rubocop-rails

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 


### PR DESCRIPTION
Update rubocop styleguide to use `plugins` to configure `rubocop-performance` and `rubocop-rails`.

Using require is deprecated for these gems:

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /Users/timflapper/streem/backend/.rubocop-https---raw-githubusercontent-com-streemau-styleguides-master-ruby--rubocop-yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```